### PR TITLE
Add benchmark for romeric/Fastor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "vendor/benchmark"]
 	path = vendor/benchmark
 	url = https://github.com/google/benchmark.git
+[submodule "vendor/Fastor"]
+	path = vendor/Fastor
+	url = https://github.com/romeric/Fastor.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(robotics_benchmarks)
 
 set(CMAKE_CXX_STANDARD 17)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall")
+
 # Default to Release build
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
@@ -14,15 +16,18 @@ if(NOT BUILD_DYNAMIC)
   set(BUILD_SHARED_LIBS OFF)
   set(CMAKE_EXE_LINKER_FLAGS
       "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++ -static")
-  # only find static libraries (for librt needed by benchmark)
+  # only find static libraries (for librt needed by benchmark).
   set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
 
-  # Some additional magic needed to properly link statically when using threads.
+  # Some additional magic needed to properly link statically when using pthread.
   # https://stackoverflow.com/a/45271521
-  set(CMAKE_EXE_LINKER_FLAGS
-      "${CMAKE_EXE_LINKER_FLAGS} -Wl,--whole-archive -lpthread -Wl,--no-whole-archive")
+  set(
+    CMAKE_EXE_LINKER_FLAGS
+    "${CMAKE_EXE_LINKER_FLAGS} -Wl,--whole-archive -lpthread -Wl,--no-whole-archive"
+    )
 endif()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
 
 set(BENCHMARK_ENABLE_TESTING OFF
     CACHE BOOL "Suppressing benchmark's tests"
@@ -31,5 +36,5 @@ add_subdirectory(vendor/benchmark)
 
 add_executable(bm src/kalman.cc)
 target_compile_options(bm PRIVATE -Wall -Werror)
-target_include_directories(bm SYSTEM PUBLIC vendor/eigen)
+target_include_directories(bm SYSTEM PUBLIC vendor/eigen vendor vendor/Fastor)
 target_link_libraries(bm benchmark)

--- a/src/kalman.cc
+++ b/src/kalman.cc
@@ -1,9 +1,13 @@
-#include <benchmark/benchmark.h>
 #include <Eigen/Dense>
+#include <Fastor/Fastor.h>
+#include <benchmark/benchmark.h>
 
 #include <algorithm>
 #include <iostream>
+#include <random>
 #include <vector>
+
+std::uniform_int_distribution<int> int_distribution(0, 100);
 
 template <int CStateSize, int CObsSize = 3, typename NumType = double>
 static void CovarianceUpdateEigen(benchmark::State &state) {
@@ -18,18 +22,23 @@ static void CovarianceUpdateEigen(benchmark::State &state) {
   const int obsSize = CObsSize;
 
   Matrix<NumType, CStateSize, CStateSize> P_x;  // covariance matrix
-  // Random symmetric matrix for the initial covariance.
-  P_x = Matrix<NumType, Dynamic, Dynamic>::Random(stateSize, stateSize);
+  P_x.resize(stateSize, stateSize);
+  P_x.setOnes();
   P_x = (P_x.transpose() * P_x).eval();
 
   Matrix<NumType, CObsSize, CStateSize> H_dx;  // observation model
-  // Observation model.
-  H_dx = Matrix<NumType, Dynamic, Dynamic>::Zero(obsSize, stateSize);
+  H_dx.resize(obsSize, stateSize);
+  H_dx.setOnes();
 
   Matrix<NumType, CObsSize, CObsSize> R_meas;  // measurement noise
-  // Random symmetric matrix for measurement noise.
-  R_meas = Matrix<NumType, Dynamic, Dynamic>::Random(obsSize, obsSize);
-  R_meas = (R_meas.transpose() * R_meas).eval();
+  R_meas.resize(obsSize, obsSize);
+  std::default_random_engine eng(0);
+  for (int i = 0; i < obsSize; i++) {
+    for (int j = 0; j < obsSize; j++) {
+      R_meas(i, j) = int_distribution(eng);
+    }
+  }
+  R_meas = R_meas.transpose() * R_meas;
 
   // scratch space for computations
   Matrix<NumType, CStateSize, CObsSize> K_gain;
@@ -57,16 +66,60 @@ static void CovarianceUpdateEigen(benchmark::State &state) {
   }
 }
 
-#define GENERATE_EIGEN_DYNAMIC_AND_STATIC_FOR_SIZE(n)   \
+template <int CStateSize, int CObsSize = 3, typename NumType = double>
+static void CovarianceUpdateFastor(benchmark::State &state) {
+  using Fastor::inverse;
+  using Fastor::matmul;
+  using Fastor::Tensor;
+  using Fastor::transpose;
+
+  Tensor<NumType, CStateSize, CStateSize> P_x;
+  P_x.ones();
+  P_x = matmul(transpose(P_x), P_x);
+
+  Tensor<NumType, CObsSize, CStateSize> H_dx;
+  H_dx.ones();
+
+  Tensor<NumType, CObsSize, CObsSize> R_meas;
+  std::default_random_engine eng(0);
+  for (int i = 0; i < CObsSize; i++) {
+    for (int j = 0; j < CObsSize; j++) {
+      R_meas(i, j) = int_distribution(eng);
+    }
+  }
+  R_meas = Fastor::matmul(transpose(R_meas), R_meas);
+
+  Tensor<NumType, CStateSize, CObsSize> K_gain;
+  Tensor<NumType, CObsSize, CObsSize> S_res;
+  Tensor<NumType, CStateSize, CStateSize> I_KH;
+  Tensor<NumType, CStateSize, CStateSize> P_x_ref;
+
+  for (auto _ : state) {
+    S_res = matmul(matmul(H_dx, P_x), transpose(H_dx)) + R_meas;
+    K_gain = matmul(matmul(P_x, transpose(H_dx)), inverse(S_res));
+
+    I_KH.eye();
+    I_KH -= matmul(K_gain, H_dx);
+
+    P_x_ref = matmul(matmul(I_KH, P_x), transpose(I_KH));
+    P_x_ref += matmul(matmul(K_gain, R_meas), transpose(K_gain));
+
+    benchmark::DoNotOptimize(P_x_ref);
+    benchmark::ClobberMemory();
+  }
+}
+
+#define COVARIANCE_UPDATE_FOR_SIZE(n)                   \
+  BENCHMARK_TEMPLATE(CovarianceUpdateFastor, n);        \
   BENCHMARK_TEMPLATE(CovarianceUpdateEigen, n)->Arg(n); \
   BENCHMARK_TEMPLATE(CovarianceUpdateEigen, Eigen::Dynamic)->Arg(n);
 
-GENERATE_EIGEN_DYNAMIC_AND_STATIC_FOR_SIZE(8);
-GENERATE_EIGEN_DYNAMIC_AND_STATIC_FOR_SIZE(16);
-GENERATE_EIGEN_DYNAMIC_AND_STATIC_FOR_SIZE(32);
-GENERATE_EIGEN_DYNAMIC_AND_STATIC_FOR_SIZE(64);
-GENERATE_EIGEN_DYNAMIC_AND_STATIC_FOR_SIZE(128);
+COVARIANCE_UPDATE_FOR_SIZE(8);
+COVARIANCE_UPDATE_FOR_SIZE(16);
+COVARIANCE_UPDATE_FOR_SIZE(32);
+COVARIANCE_UPDATE_FOR_SIZE(64);
+COVARIANCE_UPDATE_FOR_SIZE(128);
 
-#undef GENERATE_EIGEN_DYNAMIC_STATIC_FOR_SIZE
+#undef COVARIANCE_UPDATE_FOR_SIZE
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
Add benchmarks for this new linear algebra library https://github.com/romeric/Fastor

Performance on small matrix sizes is great (~2x faster than Eigen):

```
Run on (8 X 4900 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 256 KiB (x8)
  L3 Unified 12288 KiB (x1)
Load Average: 1.08, 0.79, 0.41
------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations
------------------------------------------------------------------------------------
CovarianceUpdateFastor<8>                        241 ns          241 ns      2836716
CovarianceUpdateEigen<8>/8                       393 ns          393 ns      1771414
CovarianceUpdateEigen<Eigen::Dynamic>/8          822 ns          822 ns       830852
CovarianceUpdateFastor<16>                      1144 ns         1144 ns       610699
CovarianceUpdateEigen<16>/16                    2117 ns         2117 ns       333241
CovarianceUpdateEigen<Eigen::Dynamic>/16        2352 ns         2352 ns       298774
CovarianceUpdateFastor<32>                      7689 ns         7689 ns        90656
CovarianceUpdateEigen<32>/32                    9936 ns         9936 ns        69588
CovarianceUpdateEigen<Eigen::Dynamic>/32        8752 ns         8752 ns        78695
CovarianceUpdateFastor<64>                     44389 ns        44389 ns        15646
CovarianceUpdateEigen<64>/64                   49503 ns        49503 ns        13345
CovarianceUpdateEigen<Eigen::Dynamic>/64       48440 ns        48440 ns        14342
CovarianceUpdateFastor<128>                   449163 ns       449160 ns         1584
CovarianceUpdateEigen<128>/128                339488 ns       339446 ns         2104
CovarianceUpdateEigen<Eigen::Dynamic>/128     330540 ns       330537 ns         2167
```